### PR TITLE
Fix secrets file path resolution

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,9 +41,11 @@ from replicate_api import (
 # Konstante Pfade & Limits
 # =========================
 APP_TITLE = "Flux – Bildgenerator & Upscaler"
-SAVE_DIR = Path("./KI-Bilder")
-CONFIG_PATH = Path(".streamlit/config.yaml")
-SECRETS_PATH = Path(".streamlit/secrets.toml")
+# Basispfad der App (unabhängig vom aktuellen Arbeitsverzeichnis)
+BASE_DIR = Path(__file__).resolve().parent
+SAVE_DIR = BASE_DIR / "KI-Bilder"
+CONFIG_PATH = BASE_DIR / ".streamlit" / "config.yaml"
+SECRETS_PATH = BASE_DIR / ".streamlit" / "secrets.toml"
 MAX_UPLOAD_BYTES = 50 * 1024 * 1024  # 50 MB
 
 # Modelle

--- a/app.py
+++ b/app.py
@@ -42,7 +42,29 @@ from replicate_api import (
 # =========================
 APP_TITLE = "Flux – Bildgenerator & Upscaler"
 # Basispfad der App (unabhängig vom aktuellen Arbeitsverzeichnis)
-BASE_DIR = Path(__file__).resolve().parent
+def _determine_base_dir() -> Path:
+    """Bestimme das Verzeichnis der originalen Streamlit-App.
+
+    Bei `streamlit run` kopiert Streamlit die Datei in ein temporäres Verzeichnis,
+    sodass `__file__` sonst auf diesen Zwischenspeicher zeigen würde. Wenn möglich
+    verwenden wir daher den Pfad der Haupt-Skriptdatei aus dem Streamlit-Kontext.
+    Falls kein Kontext verfügbar ist (z.B. beim Kompilieren), wird auf `__file__`
+    zurückgegriffen.
+    """
+
+    try:  # Streamlit >=1.25
+        from streamlit.runtime.scriptrunner import get_script_run_ctx  # type: ignore
+
+        ctx = get_script_run_ctx()
+        if ctx and ctx.main_script_path:
+            return Path(ctx.main_script_path).resolve().parent
+    except Exception:
+        pass
+
+    return Path(__file__).resolve().parent
+
+
+BASE_DIR = _determine_base_dir()
 SAVE_DIR = BASE_DIR / "KI-Bilder"
 CONFIG_PATH = BASE_DIR / ".streamlit" / "config.yaml"
 SECRETS_PATH = BASE_DIR / ".streamlit" / "secrets.toml"

--- a/app.py
+++ b/app.py
@@ -225,9 +225,11 @@ def set_user_password_in_yaml(username: str, new_password: str) -> None:
 # ===========
 def load_config() -> AppConfig:
     secrets = _load_secrets()
+
+    token = secrets.get("replicate_api_token") or os.getenv("REPLICATE_API_TOKEN")
+
     if "credentials" in secrets and "cookie" in secrets:
         cookie = secrets["cookie"]
-        token = secrets.get("replicate_api_token") or os.getenv("REPLICATE_API_TOKEN")
         return AppConfig(
             credentials=dict(secrets["credentials"]),
             cookie_name=str(cookie.get("name", "app_auth")),
@@ -250,7 +252,8 @@ def load_config() -> AppConfig:
 
     try:
         cookie_cfg = cfg["cookie"]
-        token = cfg.get("replicate_api_token") or os.getenv("REPLICATE_API_TOKEN")
+        if not token:
+            token = cfg.get("replicate_api_token")
         return AppConfig(
             credentials=cfg["credentials"],
             cookie_name=cookie_cfg["name"],


### PR DESCRIPTION
## Summary
- ensure `secrets.toml` and other paths resolve relative to the app directory instead of the current working directory

## Testing
- `python -m py_compile app.py replicate_api.py && echo 'OK'`


------
https://chatgpt.com/codex/tasks/task_e_68b9e4ad99b48322aea94c6be74f5364